### PR TITLE
chore: change input-param type

### DIFF
--- a/cpp/include/darabonba/util.hpp
+++ b/cpp/include/darabonba/util.hpp
@@ -110,49 +110,82 @@ public:
 };
 class Client {
 public:
-  static vector<uint8_t> toBytes(const shared_ptr<string> &val);
-  static string toString(const shared_ptr<vector<uint8_t>> &val);
-  static boost::any parseJSON(const shared_ptr<string> &val);
-  static vector<uint8_t>
-  readAsBytes(const shared_ptr<Darabonba::Stream> &stream);
-  static string readAsString(const shared_ptr<Darabonba::Stream> &stream);
-  static boost::any readAsJSON(const shared_ptr<Darabonba::Stream> &stream);
+  /************************** helper **************************/
   static string getNonce();
+
   static string getDateUTCString();
+
+  static string getUserAgent(const shared_ptr<string> &userAgent);
+
+  static void sleep(const shared_ptr<int> &millisecond);
+
+  static void validateModel(const shared_ptr<Darabonba::Model> &m);
+
+  /************************** default **************************/
   static string defaultString(const shared_ptr<string> &real,
                               const shared_ptr<string> &default_);
+
   static int defaultNumber(const shared_ptr<int> &real,
                            const shared_ptr<int> &default_);
-  static string toFormString(shared_ptr<map<string, boost::any>> val);
-  static string toJSONString(const shared_ptr<boost::any> &val);
-  static bool empty(const shared_ptr<string> &val);
-  static bool equalString(const shared_ptr<string> &val1,
-                          const shared_ptr<string> &val2);
-  static bool equalNumber(const shared_ptr<int> &val1,
-                          const shared_ptr<int> &val2);
-  static bool isUnset(const shared_ptr<void> &value);
+
+  /************************** parse **************************/
   static map<string, string>
   stringifyMapValue(const shared_ptr<map<string, boost::any>> &m);
+
   static map<string, boost::any>
   anyifyMapValue(const shared_ptr<map<string, string>> &m);
-  static bool assertAsBoolean(const shared_ptr<boost::any> &value);
-  static string assertAsString(const shared_ptr<boost::any> &value);
-  static vector<uint8_t> assertAsBytes(const shared_ptr<boost::any> &value);
-  static int assertAsNumber(const shared_ptr<boost::any> &value);
-  static map<string, boost::any>
-  assertAsMap(const shared_ptr<boost::any> &value);
-  static string getUserAgent(const shared_ptr<string> &userAgent);
-  static bool is2xx(const shared_ptr<int> &code);
-  static bool is3xx(const shared_ptr<int> &code);
-  static bool is4xx(const shared_ptr<int> &code);
-  static bool is5xx(const shared_ptr<int> &code);
-  static void validateModel(const shared_ptr<Darabonba::Model> &m);
+
   static map<string, boost::any> toMap(const shared_ptr<Darabonba::Model> &in);
-  static void sleep(const shared_ptr<int> &millisecond);
-  static vector<map<string, boost::any>>
-  toArray(const shared_ptr<boost::any> &input);
-  static Darabonba::Stream
-  assertAsReadable(const shared_ptr<boost::any> &value);
+
+  static vector<uint8_t> toBytes(const shared_ptr<string> &val);
+
+  static string toString(const shared_ptr<vector<uint8_t>> &val);
+
+  static vector<map<string, boost::any>> toArray(const shared_ptr<void> &input);
+
+  static string toFormString(shared_ptr<map<string, boost::any>> val);
+
+  static string toJSONString(const shared_ptr<void> &val);
+
+  static boost::any parseJSON(const shared_ptr<string> &val);
+
+  static vector<uint8_t>
+  readAsBytes(const shared_ptr<Darabonba::Stream> &stream);
+
+  static string readAsString(const shared_ptr<Darabonba::Stream> &stream);
+
+  static boost::any readAsJSON(const shared_ptr<Darabonba::Stream> &stream);
+
+  /************************** assert **************************/
+  static bool isUnset(const shared_ptr<void> &value);
+
+  static bool assertAsBoolean(const shared_ptr<void> &value);
+
+  static bool empty(const shared_ptr<string> &val);
+
+  static bool equalString(const shared_ptr<string> &val1,
+                          const shared_ptr<string> &val2);
+
+  static bool equalNumber(const shared_ptr<int> &val1,
+                          const shared_ptr<int> &val2);
+
+  static string assertAsString(const shared_ptr<void> &value);
+
+  static vector<uint8_t> assertAsBytes(const shared_ptr<void> &value);
+
+  static int assertAsNumber(const shared_ptr<void> &value);
+
+  static map<string, boost::any> assertAsMap(const shared_ptr<void> &value);
+
+  static Darabonba::Stream assertAsReadable(const shared_ptr<void> &value);
+
+  static bool is2xx(const shared_ptr<int> &code);
+
+  static bool is3xx(const shared_ptr<int> &code);
+
+  static bool is4xx(const shared_ptr<int> &code);
+
+  static bool is5xx(const shared_ptr<int> &code);
 
   Client(){};
   ~Client(){};

--- a/cpp/src/assert.cpp
+++ b/cpp/src/assert.cpp
@@ -67,69 +67,71 @@ map<string, string> Darabonba_Util::Client::stringifyMapValue(
   return data;
 }
 
-bool Darabonba_Util::Client::assertAsBoolean(
-    const shared_ptr<boost::any> &value) {
+bool Darabonba_Util::Client::assertAsBoolean(const shared_ptr<void> &value) {
   if (!value) {
     BOOST_THROW_EXCEPTION(
         boost::enable_error_info(runtime_error("value is nullptr")));
   }
-  if (typeid(bool) != value->type()) {
+  shared_ptr<boost::any> val = static_pointer_cast<boost::any>(value);
+  if (typeid(bool) != val->type()) {
     BOOST_THROW_EXCEPTION(
         boost::enable_error_info(runtime_error("value is not a bool")));
   }
-  return boost::any_cast<bool>(*value);
+  return boost::any_cast<bool>(*val);
 }
 
-string
-Darabonba_Util::Client::assertAsString(const shared_ptr<boost::any> &value) {
+string Darabonba_Util::Client::assertAsString(const shared_ptr<void> &value) {
   if (!value) {
     BOOST_THROW_EXCEPTION(
         boost::enable_error_info(runtime_error("value is nullptr")));
   }
-  if (typeid(string) != value->type()) {
+  shared_ptr<boost::any> val = static_pointer_cast<boost::any>(value);
+  if (typeid(string) != val->type()) {
     BOOST_THROW_EXCEPTION(
         boost::enable_error_info(runtime_error("value is not a string")));
   }
-  return boost::any_cast<string>(*value);
+  return boost::any_cast<string>(*val);
 }
 
 vector<uint8_t>
-Darabonba_Util::Client::assertAsBytes(const shared_ptr<boost::any> &value) {
+Darabonba_Util::Client::assertAsBytes(const shared_ptr<void> &value) {
   if (!value) {
     BOOST_THROW_EXCEPTION(
         boost::enable_error_info(runtime_error("value is nullptr")));
   }
-  if (typeid(vector<uint8_t>) != value->type()) {
+  shared_ptr<boost::any> val = static_pointer_cast<boost::any>(value);
+  if (typeid(vector<uint8_t>) != val->type()) {
     BOOST_THROW_EXCEPTION(
         boost::enable_error_info(runtime_error("value is not a bytes")));
   }
-  return boost::any_cast<vector<uint8_t>>(*value);
+  return boost::any_cast<vector<uint8_t>>(*val);
 }
 
-int Darabonba_Util::Client::assertAsNumber(
-    const shared_ptr<boost::any> &value) {
+int Darabonba_Util::Client::assertAsNumber(const shared_ptr<void> &value) {
   if (!value) {
     BOOST_THROW_EXCEPTION(
         boost::enable_error_info(runtime_error("value is nullptr")));
   }
-  if (typeid(int) != value->type()) {
+  shared_ptr<boost::any> val = static_pointer_cast<boost::any>(value);
+  if (typeid(int) != val->type()) {
     BOOST_THROW_EXCEPTION(
         boost::enable_error_info(runtime_error("value is not a int number")));
   }
-  return boost::any_cast<int>(*value);
+  return boost::any_cast<int>(*val);
 }
 
 map<string, boost::any>
-Darabonba_Util::Client::assertAsMap(const shared_ptr<boost::any> &value) {
+Darabonba_Util::Client::assertAsMap(const shared_ptr<void> &value) {
   if (!value) {
     BOOST_THROW_EXCEPTION(
         boost::enable_error_info(runtime_error("value is nullptr")));
   }
-  if (typeid(map<string, boost::any>) != value->type()) {
+  shared_ptr<boost::any> val = static_pointer_cast<boost::any>(value);
+  if (typeid(map<string, boost::any>) != val->type()) {
     BOOST_THROW_EXCEPTION(boost::enable_error_info(
         runtime_error("value is not a map<string, any>")));
   }
-  return boost::any_cast<map<string, boost::any>>(*value);
+  return boost::any_cast<map<string, boost::any>>(*val);
 }
 
 bool Darabonba_Util::Client::is2xx(const shared_ptr<int> &code) {
@@ -149,15 +151,16 @@ bool Darabonba_Util::Client::is5xx(const shared_ptr<int> &code) {
 }
 
 Darabonba::Stream
-Darabonba_Util::Client::assertAsReadable(const shared_ptr<boost::any> &value) {
+Darabonba_Util::Client::assertAsReadable(const shared_ptr<void> &value) {
   if (!value) {
     BOOST_THROW_EXCEPTION(
         boost::enable_error_info(runtime_error("value is nullptr")));
   }
-  if (typeid(Darabonba::Stream) != value->type()) {
+  shared_ptr<boost::any> val = static_pointer_cast<boost::any>(value);
+  if (typeid(Darabonba::Stream) != val->type()) {
     BOOST_THROW_EXCEPTION(
         boost::enable_error_info(runtime_error("value is not a readable")));
   }
-  Darabonba::Stream f = boost::any_cast<Darabonba::Stream>(*value);
+  Darabonba::Stream f = boost::any_cast<Darabonba::Stream>(*val);
   return f;
 }

--- a/cpp/src/parse.cpp
+++ b/cpp/src/parse.cpp
@@ -5,9 +5,9 @@
 #include <cpprest/streams.h>
 #include <darabonba/util.hpp>
 #include <json/json.h>
+#include <regex>
 #include <sstream>
 #include <string>
-#include <regex>
 
 using namespace std;
 
@@ -155,11 +155,13 @@ void json_encode(boost::any val, stringstream &ss) {
   }
 }
 
-string Darabonba_Util::Client::toJSONString(const shared_ptr<boost::any> &val) {
+string Darabonba_Util::Client::toJSONString(const shared_ptr<void> &val) {
   if (!val) {
     return string("{}");
   }
-  map<string, boost::any> a = boost::any_cast<map<string, boost::any>>(*val);
+  string b = typeid(val).name();
+  shared_ptr<boost::any> v = static_pointer_cast<boost::any>(val);
+  map<string, boost::any> a = boost::any_cast<map<string, boost::any>>(*v);
   stringstream s;
   json_encode(a, s);
   return s.str();
@@ -222,11 +224,12 @@ map<string, boost::any> Darabonba_Util::Client::anyifyMapValue(
 }
 
 vector<map<string, boost::any>>
-Darabonba_Util::Client::toArray(const shared_ptr<boost::any> &input) {
+Darabonba_Util::Client::toArray(const shared_ptr<void> &input) {
   if (!input) {
     return vector<map<string, boost::any>>();
   }
-  map<string, boost::any> m = boost::any_cast<map<string, boost::any>>(*input);
+  shared_ptr<boost::any> a = static_pointer_cast<boost::any>(input);
+  map<string, boost::any> m = boost::any_cast<map<string, boost::any>>(*a);
   vector<map<string, boost::any>> v;
   v.push_back(m);
   return v;

--- a/cpp/tests/parse.cpp
+++ b/cpp/tests/parse.cpp
@@ -82,7 +82,8 @@ TEST(tests_parse, readAsString) {
 }
 
 TEST(tests_parse, readAsJSON) {
-  string json(R"({"test": "string", "int": 100, "long": -9999999999, "double": 1.0212199})");
+  string json(
+      R"({"test": "string", "int": 100, "long": -9999999999, "double": 1.0212199})");
   concurrency::streams::stringstreambuf string_buf(json);
 
   map<string, boost::any> res = boost::any_cast<map<string, boost::any>>(
@@ -100,7 +101,6 @@ TEST(tests_parse, readAsJSON) {
 
   ASSERT_EQ(string("test"), boost::any_cast<string>(array[0]));
   ASSERT_EQ(string("string"), boost::any_cast<string>(array[1]));
-
 }
 
 TEST(test_parse, toFormString) {


### PR DESCRIPTION
use void instead of boost::any for input-param