### PR TITLE
fix: 🐛 to_jsonstring whitespace and non-ASCII characters

### DIFF
--- a/python/alibabacloud_tea_util/client.py
+++ b/python/alibabacloud_tea_util/client.py
@@ -221,7 +221,9 @@ class Client:
         """
         if isinstance(val, str):
             return str(val)
-        return json.dumps(val, cls=Client.__ModelEncoder)
+        return json.dumps(
+            val, cls=Client.__ModelEncoder, ensure_ascii=False, separators=(",", ":")
+        )
 
     @staticmethod
     def empty(

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -106,7 +106,7 @@ class TestClient(unittest.TestCase):
     def test_to_json_string(self):
         self.assertEqual('test string for to_jsonstring',
                          Client.to_jsonstring('test string for to_jsonstring'))
-        self.assertEqual('{"key": "value"}',
+        self.assertEqual('{"key":"value"}',
                          Client.to_jsonstring({"key": "value"}))
         model = self.TestModel()
         any_dict = {
@@ -115,10 +115,11 @@ class TestClient(unittest.TestCase):
             'int': 100,
             'model': model,
             'float': 100.1,
-            'bool': True
+            'bool': True,
+            'utf8': '你好'
         }
         self.assertEqual(
-            '{"bytes": "100", "str": "100", "int": 100, "model": {"test_a": "a", "test_b": "b"}, "float": 100.1, "bool": true}',
+            '{"bytes":"100","str":"100","int":100,"model":{"test_a":"a","test_b":"b"},"float":100.1,"bool":true,"utf8":"你好"}',
             Client.to_jsonstring(any_dict)
         )
 

--- a/python2/alibabacloud_tea_util/client.py
+++ b/python2/alibabacloud_tea_util/client.py
@@ -160,8 +160,9 @@ class Client(object):
         """
         if isinstance(val, str):
             return str(val)
-        return json.dumps(val, cls=Client._ModelEncoder)
-
+        return json.dumps(
+            val, cls=Client._ModelEncoder, ensure_ascii=False, separators=(",", ":")
+        )
     @staticmethod
     def empty(val):
         """

--- a/python2/tests/test_client.py
+++ b/python2/tests/test_client.py
@@ -107,20 +107,21 @@ class TestClient(unittest.TestCase):
     def test_to_json_string(self):
         self.assertEqual('test string for to_jsonstring',
                          Client.to_jsonstring('test string for to_jsonstring'))
-        self.assertEqual('{"key": "value"}',
+        self.assertEqual('{"key":"value"}',
                          Client.to_jsonstring({"key": "value"}))
         model = self.TestModel()
         any_dict = {
             'bytes': '100',
-            'str': u'100',
+            'str': '100',
             'int': 100,
             'model': model,
             'float': 100.1,
             'bool': True,
             'None': None,
+            'utf8': '你好'
         }
         self.assertEqual(
-            '{"None": null, "int": 100, "float": 100.1, "bytes": "100", "bool": true, "str": "100", "model": {"test_b": "b", "test_a": "a"}}',
+            '{"None":null,"bool":true,"str":"100","int":100,"utf8":"你好","model":{"test_b":"b","test_a":"a"},"float":100.1,"bytes":"100"}',
             Client.to_jsonstring(any_dict)
         )
 


### PR DESCRIPTION
As following code shows, `json.dumps`'s default behavior will keep whitespace for beaufity and have all incoming non-ASCII characters escaped.
So we  should specify `separators=(',', ':')` to eliminate whitespace and `ensure_ascii=False` to  encure these characters will be output as-is.
### Reference:
* [json — JSON encoder and decoder &#8212; Python 3.9.16 documentation](https://docs.python.org/3.9/library/json.html?highlight=separators#json.dump)
* I have tested `json_to_string` function in java and golang. Both of them behaved as expected.
```python
In [1]: import json

In [2]: body = {"a":"hello","b":"你好"}

In [3]: json.dumps(body)
Out[3]: '{"a": "hello", "b": "\\u4f60\\u597d"}'

In [4]: json.dumps(body, ensure_ascii=False, separators=(",", ":"))
Out[4]: '{"a":"hello","b":"你好"}'
```